### PR TITLE
Add optional melnode-addr CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,8 +1489,7 @@ dependencies = [
 [[package]]
 name = "melprot"
 version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d450ed39b4f3cfa6640695d40f80d52d1ad3807a8516c24222d3cc227850fcd"
+source = "git+https://github.com/mel-project/melprot?branch=autoconnect-with-truststore#412b32618e4fc4d455bcec121379260478f06be6"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,31 +25,32 @@ repository = "https://github.com/themeliolabs/melwallet-client"
 
 [dependencies]
 # tmelcrypt = { git = "https://github.com/themeliolabs/themelio-core" }
-tmelcrypt= "0.2.4"
-smolscale= "0.3.23"
-stdcode= "0.1.7"
+tmelcrypt = "0.2.4"
+smolscale = "0.3.23"
+stdcode = "0.1.7"
 
-serde={ version = "1.0.136", features = ["derive"] }
-anyhow= "1.0.56"
+serde = { version = "1.0.136", features = ["derive"] }
+anyhow = "1.0.56"
 tracing-subscriber = "0.3.9"
-log= "0.4.16"
-tracing= "0.1.32"
-smol= "1.2.5"
-serde_json= { version = "1.0.79", features = ["arbitrary_precision"] }
-colored= "2.0.0"
-tabwriter={ version = "1.2.1", features = ["ansi_formatting"] }
-hex= "0.4.3"
+log = "0.4.16"
+tracing = "0.1.32"
+smol = "1.2.5"
+serde_json = { version = "1.0.79", features = ["arbitrary_precision"] }
+colored = "2.0.0"
+tabwriter = { version = "1.2.1", features = ["ansi_formatting"] }
+hex = "0.4.3"
 once_cell = "1.10.0"
 getrandom = "0.2.5"
-thiserror= "1.0.30"
+thiserror = "1.0.30"
 
 rpassword = "7.0.0"
 clap = { version = "4.1.2", features = ["derive", "cargo"] }
-clap_complete = "4.1.1" 
+clap_complete = "4.1.1"
 terminal_size = "0.2.1"
 
 melvm = "0.1.0"
 melstructs = "0.3.2"
+# melstructs = { path = "../melstructs" }
 melwallet = "0.1"
 #melwallet = {git = "https://github.com/mel-project/melwallet", branch = "master"}
 # melwallet = {path = "../melwallet"}
@@ -61,8 +62,9 @@ ed25519-dalek = "1.0.1"
 futures-util = "0.3.28"
 melnet2 = "0.3.1"
 melbootstrap = "0.8.4"
-melprot = "0.13.7"
-# melprot = {path = "../melprot"}
+# melprot = "0.13.7"
+# melprot = { path = "../melprot" }
+melprot = { git = "https://github.com/mel-project/melprot", branch = "autoconnect-with-truststore" }
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,17 +2,22 @@ use anyhow::Context;
 
 use clap::Parser;
 use melstructs::{Address, CoinData, CoinID, CoinValue, Denom, NetID, PoolKey};
-use std::str::FromStr;
+use std::{net::SocketAddr, str::FromStr};
 use tmelcrypt::HashVal;
 
 #[derive(Parser, Clone, Debug)]
 /// Mel Wallet Command Line Interface
 pub struct Args {
     #[clap(long)]
-    // path to the wallet to create or use
+    // Path to the wallet to create or use
     pub wallet_path: String,
+
     #[clap(subcommand)]
     pub subcommand: SubcommandArgs,
+
+    // An optional address to the melnode your wallet will point to
+    #[clap(long)]
+    pub melnode_addr: Option<SocketAddr>,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn main() -> anyhow::Result<()> {
         let Args {
             wallet_path,
             subcommand,
+            melnode_addr,
         } = Args::parse();
 
         // create wallet if that's the command, *before* we try to open it by creating the state
@@ -107,7 +108,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         // create melwallet-cli state
-        let state = State::new(&wallet_path).await?;
+        let state = State::new(&wallet_path, melnode_addr).await?;
         // sync wallet with network
         state.sync_wallet().await?;
         // println!("finished syncing wallet!");

--- a/src/persistent_truststore.rs
+++ b/src/persistent_truststore.rs
@@ -12,40 +12,42 @@ pub struct PersistentTrustStore {
 
 impl PersistentTrustStore {
     pub fn new(file_path: &str) -> anyhow::Result<Self> {
-        let inner = if Path::new(file_path).exists() {
-            let contents = std::fs::read(file_path).context("could not read trust store file")?;
-            match serde_json::from_slice::<HashMap<NetID, Checkpoint>>(&contents) {
-                Ok(data) => Arc::new(RwLock::new(data)),
-                Err(err) => {
-                    eprintln!("Initializing trust store with empty data");
-                    Arc::new(RwLock::new(HashMap::new()))
-                }
-            }
-        } else {
-            Arc::new(RwLock::new(HashMap::new()))
-        };
-
-        Ok(Self {
-            file_path: file_path.to_string(),
-            inner,
-        })
+        todo!()
+        // let inner = if Path::new(file_path).exists() {
+        //     let contents = std::fs::read(file_path).context("could not read trust store file")?;
+        //     match serde_json::from_slice::<HashMap<NetID, Checkpoint>>(&contents) {
+        //         Ok(data) => Arc::new(RwLock::new(data)),
+        //         Err(err) => {
+        //             eprintln!("Initializing trust store with empty data");
+        //             Arc::new(RwLock::new(HashMap::new()))
+        //         }
+        //     }
+        // } else {
+        //     Arc::new(RwLock::new(HashMap::new()))
+        // };
+        //
+        // Ok(Self {
+        //     file_path: file_path.to_string(),
+        //     inner,
+        // })
     }
 }
 
 impl TrustStore for PersistentTrustStore {
     fn set(&self, netid: NetID, trusted: Checkpoint) {
-        let mut inner = self.inner.write().unwrap();
-        if let Some(old) = inner.get(&netid) {
-            if old.height >= trusted.height {
-                return;
-            }
-        }
-        inner.insert(netid, trusted);
-        std::fs::write(
-            &self.file_path,
-            serde_json::to_string(&inner.clone()).unwrap(),
-        )
-        .unwrap();
+        todo!()
+        // let mut inner = self.inner.write().unwrap();
+        // if let Some(old) = inner.get(&netid) {
+        //     if old.height >= trusted.height {
+        //         return;
+        //     }
+        // }
+        // inner.insert(netid, trusted);
+        // std::fs::write(
+        //     &self.file_path,
+        //     serde_json::to_string(&inner.clone()).unwrap(),
+        // )
+        // .unwrap();
     }
 
     fn get(&self, netid: NetID) -> Option<Checkpoint> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,6 +52,7 @@ impl State {
         let netid = wwk.read().wallet.netid;
 
         let melclient = if let Some(melnode_addr) = melnode_addr {
+            // TODO: add a trust store here if needed as well?
             Client::connect_http(netid, melnode_addr).await?
         } else {
             let trust_store = PersistentTrustStore::new(&(wallet_path.to_owned() + ".store"))?;


### PR DESCRIPTION
You can now point your wallet a custom melnode address like `melwallet-cli --melnode-addr 127.0.0.1:41814 --wallet-path <wallet-path> summary`.

This comments out the `persistent_store` functionality temporarily, since `melstructs::Checkpoint` doesn't implement `serde::Serialize/Deserialize` yet. 

This points to a branch on `melprot` until the [change](https://github.com/mel-project/melprot/pull/9/files) is merged.